### PR TITLE
More vim-like navigation

### DIFF
--- a/src/gui/HotkeyPickerDrawer.cpp
+++ b/src/gui/HotkeyPickerDrawer.cpp
@@ -98,7 +98,7 @@ void HotkeyPickerDrawer::goToHotkey(long hotkeyIdx) {
     drawFrame(hotkey);
 }
 
-bool HotkeyPickerDrawer::move(HotkeyPickerMove move) {
+bool HotkeyPickerDrawer::move(HotkeyPickerMove move, unsigned int steps) {
     bool canMove = false;
     long newSelectedShapeIdx = 0;
 
@@ -106,23 +106,23 @@ bool HotkeyPickerDrawer::move(HotkeyPickerMove move) {
 
     switch (move) {
         case HotkeyPickerMove::LEFT:
-            canMove = selectedShape->index >= 1;
-            newSelectedShapeIdx = selectedShape->index - 1;
+            canMove = selectedShape->index >= steps;
+            newSelectedShapeIdx = selectedShape->index - steps;
             debug = "LEFT";
             break;
         case HotkeyPickerMove::RIGHT:
-            canMove = selectedShape->index + 1 < hotkeys->size();
-            newSelectedShapeIdx = selectedShape->index + 1;
+            canMove = selectedShape->index + steps < hotkeys->size();
+            newSelectedShapeIdx = selectedShape->index + steps;
             debug = "RIGHT";
             break;
         case HotkeyPickerMove::UP:
-            canMove = selectedShape->index - shapeProperties.itemCounts.x >= 0;
-            newSelectedShapeIdx = selectedShape->index - shapeProperties.itemCounts.x;
+            canMove = selectedShape->index - (steps * shapeProperties.itemCounts.x) >= 0;
+            newSelectedShapeIdx = selectedShape->index - (steps * shapeProperties.itemCounts.x);
             debug = "UP";
             break;
         case HotkeyPickerMove::DOWN:
-            canMove = selectedShape->index + shapeProperties.itemCounts.x < hotkeys->size();
-            newSelectedShapeIdx = selectedShape->index + shapeProperties.itemCounts.x;
+            canMove = selectedShape->index + (steps * shapeProperties.itemCounts.x) < hotkeys->size();
+            newSelectedShapeIdx = selectedShape->index + (steps * shapeProperties.itemCounts.x);
             debug = "DOWN";
             break;
     }

--- a/src/gui/HotkeyPickerDrawer.cpp
+++ b/src/gui/HotkeyPickerDrawer.cpp
@@ -125,6 +125,11 @@ bool HotkeyPickerDrawer::move(HotkeyPickerMove move, unsigned int steps) {
             newSelectedShapeIdx = selectedShape->index + (steps * shapeProperties.itemCounts.x);
             debug = "DOWN";
             break;
+        case HotkeyPickerMove::END:
+            canMove = selectedShape->index != hotkeys->size() - 1;
+            newSelectedShapeIdx = hotkeys->size() - 1;
+            debug = "END";
+            break;
     }
 
     printf("type: %s, canmove: %d oldIdx: %d newIdx: %d \n", debug, canMove, selectedShape->index,

--- a/src/gui/HotkeyPickerDrawer.cpp
+++ b/src/gui/HotkeyPickerDrawer.cpp
@@ -130,6 +130,15 @@ bool HotkeyPickerDrawer::move(HotkeyPickerMove move, unsigned int steps) {
             newSelectedShapeIdx = hotkeys->size() - 1;
             debug = "END";
             break;
+        case HotkeyPickerMove::HOME:
+            canMove = true;
+            newSelectedShapeIdx = 0;
+            debug = "HOME";
+            break;
+        case HotkeyPickerMove::LINE:
+            canMove = steps > 0 && shapeProperties.itemCounts.x * steps < hotkeys->size();
+            newSelectedShapeIdx = shapeProperties.itemCounts.x * (steps - 1);
+            debug = "LINE";
     }
 
     printf("type: %s, canmove: %d oldIdx: %d newIdx: %d \n", debug, canMove, selectedShape->index,

--- a/src/gui/HotkeyPickerDrawer.h
+++ b/src/gui/HotkeyPickerDrawer.h
@@ -17,7 +17,10 @@ enum class HotkeyPickerMove {
     LEFT,
     RIGHT,
     UP,
-    DOWN
+    DOWN,
+
+    HOME,
+    END
 };
 
 class HotkeyPickerDrawer {

--- a/src/gui/HotkeyPickerDrawer.h
+++ b/src/gui/HotkeyPickerDrawer.h
@@ -46,7 +46,7 @@ public:
 
     void drawFrame(Hotkey* selectedHotkey);
 
-    bool move(HotkeyPickerMove move);
+    bool move(HotkeyPickerMove move, unsigned int steps = 1);
 
     void setFilter(std::function<bool(Hotkey *)> filter);
 

--- a/src/gui/HotkeyPickerDrawer.h
+++ b/src/gui/HotkeyPickerDrawer.h
@@ -20,7 +20,9 @@ enum class HotkeyPickerMove {
     DOWN,
 
     HOME,
-    END
+    END,
+
+    LINE
 };
 
 class HotkeyPickerDrawer {

--- a/src/input/handler/InputHandler.cpp
+++ b/src/input/handler/InputHandler.cpp
@@ -3,17 +3,70 @@
 #include "instruction/ModeChangeInstruction.h"
 #include "SelectionInputHandler.h"
 #include "filters/TextFilteringInputHandler.h"
+#include "../../lib/keycode/keycode.h"
 
-Instruction *InputHandler::handleKeyPress(unsigned keyPress) {
-    if (keyPress == KEY_ESC) {
+Instruction *InputHandler::handleKeyPress(unsigned keyCode) {
+    if (keyCode == KEY_ESC) {
         return new Instruction(InstructionType::EXIT);
     }
 
-    if (keyPress == KEY_CAPSLOCK) {
+    if (keyCode == KEY_CAPSLOCK) {
         InputMode mode = getNextMode();
 
         return new ModeChangeInstruction(mode);
     }
 
+    if (isModifier(keyCode)) {
+        addModifier(keyCode);
+    }
+
     return new Instruction(InstructionType::NONE);
+}
+
+Instruction *InputHandler::handleKeyRelease(unsigned keyCode) {
+    if (isModifier(keyCode)) {
+        removeModifier(keyCode);
+    }
+
+    return new Instruction(InstructionType::NONE);
+}
+
+void InputHandler::removeModifier(unsigned keyCode) {
+    activeModifiers.erase(keyCodeToYAMLName(keyCode));
+}
+
+bool InputHandler::isModifier(unsigned keyCode) {
+    switch (keyCode) {
+        case KEY_RIGHTSHIFT:
+        case KEY_LEFTSHIFT:
+            return true;
+    }
+
+    return false;
+}
+
+void InputHandler::addModifier(unsigned keyCode) {
+    activeModifiers.insert(keyCodeToYAMLName(keyCode));
+}
+
+bool InputHandler::isModifierActive(std::string keyName) {
+    return activeModifiers.find(keyName) != activeModifiers.end();
+}
+
+/* TODO : this should be moved to another service or something as it is
+ * a duplicate of linux_rawname_to_yaml_name defined in KeyFilteringInputHandler */
+std::string InputHandler::keyCodeToYAMLName(unsigned keyCode) {
+    std::string linux_rawname = keycode_linux_rawname(keyCode);
+
+    if (linux_rawname.rfind("LEFT", 0) == 0) {
+        linux_rawname = linux_rawname.substr(4, std::string::npos);
+    } else if (linux_rawname.rfind("RIGHT", 0) == 0) {
+        linux_rawname = linux_rawname.substr(5, std::string::npos);
+    }
+
+    if (linux_rawname == "CTRL") {
+        linux_rawname = "CONTROL";
+    }
+
+    return linux_rawname;
 }

--- a/src/input/handler/InputHandler.cpp
+++ b/src/input/handler/InputHandler.cpp
@@ -32,7 +32,7 @@ Instruction *InputHandler::handleKeyRelease(unsigned keyCode) {
 }
 
 void InputHandler::removeModifier(unsigned keyCode) {
-    activeModifiers.erase(keyCodeToYAMLName(keyCode));
+    activeModifiers.erase(linux_keycode_to_yaml_name(keyCode));
 }
 
 bool InputHandler::isModifier(unsigned keyCode) {
@@ -46,27 +46,9 @@ bool InputHandler::isModifier(unsigned keyCode) {
 }
 
 void InputHandler::addModifier(unsigned keyCode) {
-    activeModifiers.insert(keyCodeToYAMLName(keyCode));
+    activeModifiers.insert(linux_keycode_to_yaml_name(keyCode));
 }
 
 bool InputHandler::isModifierActive(std::string keyName) {
     return activeModifiers.find(keyName) != activeModifiers.end();
-}
-
-/* TODO : this should be moved to another service or something as it is
- * a duplicate of linux_rawname_to_yaml_name defined in KeyFilteringInputHandler */
-std::string InputHandler::keyCodeToYAMLName(unsigned keyCode) {
-    std::string linux_rawname = keycode_linux_rawname(keyCode);
-
-    if (linux_rawname.rfind("LEFT", 0) == 0) {
-        linux_rawname = linux_rawname.substr(4, std::string::npos);
-    } else if (linux_rawname.rfind("RIGHT", 0) == 0) {
-        linux_rawname = linux_rawname.substr(5, std::string::npos);
-    }
-
-    if (linux_rawname == "CTRL") {
-        linux_rawname = "CONTROL";
-    }
-
-    return linux_rawname;
 }

--- a/src/input/handler/InputHandler.h
+++ b/src/input/handler/InputHandler.h
@@ -1,12 +1,25 @@
 #pragma once
 
 #include <string>
+#include <set>
 #include "../../hotkey/hotkey.h"
 #include "instruction/Instruction.h"
 #include "InputMode.h"
 
 class InputHandler {
 public:
-    virtual Instruction *handleKeyPress(unsigned keyPress);
+    virtual Instruction *handleKeyPress(unsigned keyCode);
+    virtual Instruction *handleKeyRelease(unsigned keyCode);
     virtual InputMode getNextMode() = 0;
+protected:
+    void addModifier(unsigned keyCode);
+    void removeModifier(unsigned keyCode);
+    bool isModifier(unsigned keyCode);
+
+    std::string keyCodeToYAMLName(unsigned keyCode);
+
+    bool isModifierActive(std::string keyName);
+
+private:
+    std::set<std::string> activeModifiers;
 };

--- a/src/input/handler/SelectionInputHandler.cpp
+++ b/src/input/handler/SelectionInputHandler.cpp
@@ -55,6 +55,14 @@ Instruction *SelectionInputHandler::handleKeyPress(unsigned keyPress) {
         repeatNextCommand = false;
     }
 
+    if(keyPress == KEY_G && isModifierActive("SHIFT"))
+    {
+        repeatNextCommand = false;
+        repeatNextCommandTimes = 1;
+
+        delete instruction;
+        instruction = new MoveInstruction(HotkeyPickerMove::END, 1);
+    }
 
     return instruction;
 }

--- a/src/input/handler/SelectionInputHandler.cpp
+++ b/src/input/handler/SelectionInputHandler.cpp
@@ -36,9 +36,25 @@ Instruction *SelectionInputHandler::handleKeyPress(unsigned keyPress) {
 
         if (move != HotkeyPickerMove::NONE) {
             delete instruction;
-            instruction = new MoveInstruction(move);
+            instruction = new MoveInstruction(move, repeatNextCommandTimes);
         }
     }
+
+    if (keyPress == KEY_0 && repeatNextCommand) {
+        repeatNextCommandTimes = repeatNextCommandTimes * 10;
+    } else if (keyPress >= KEY_1 && keyPress <= KEY_9) {
+        if (repeatNextCommand) {
+            repeatNextCommandTimes = repeatNextCommandTimes * 10 + (keyPress - 1);
+        } else {
+            repeatNextCommandTimes = keyPress - 1;
+        }
+
+        repeatNextCommand = true;
+    } else {
+        repeatNextCommandTimes = 1;
+        repeatNextCommand = false;
+    }
+
 
     return instruction;
 }

--- a/src/input/handler/SelectionInputHandler.h
+++ b/src/input/handler/SelectionInputHandler.h
@@ -8,6 +8,9 @@ public:
     Instruction *handleKeyPress(unsigned keyPress) override;
 
     InputMode getNextMode() override;
+private:
+    unsigned int repeatNextCommandTimes = 1;
+    bool repeatNextCommand = false;
 };
 
 

--- a/src/input/handler/SelectionInputHandler.h
+++ b/src/input/handler/SelectionInputHandler.h
@@ -5,7 +5,7 @@
 
 class SelectionInputHandler : public InputHandler {
 public:
-    Instruction *handleKeyPress(unsigned keyPress) override;
+    Instruction *handleKeyPress(unsigned keyCode) override;
 
     InputMode getNextMode() override;
 private:

--- a/src/input/handler/filters/KeyFilteringInputHandler.cpp
+++ b/src/input/handler/filters/KeyFilteringInputHandler.cpp
@@ -2,20 +2,6 @@
 #include "KeyFilteringInputHandler.h"
 #include "../../../lib/keycode/keycode.h"
 
-std::string linux_rawname_to_yaml_name(std::string linux_rawname) {
-    if (linux_rawname.rfind("LEFT", 0) == 0) {
-        linux_rawname = linux_rawname.substr(4, std::string::npos);
-    } else if (linux_rawname.rfind("RIGHT", 0) == 0) {
-        linux_rawname = linux_rawname.substr(5, std::string::npos);
-    }
-
-    if (linux_rawname == "CTRL") {
-        linux_rawname = "CONTROL";
-    }
-
-    return linux_rawname;
-}
-
 std::string KeyFilteringInputHandler::getFilterText() {
     std::string str;
 
@@ -29,7 +15,6 @@ std::string KeyFilteringInputHandler::getFilterText() {
 
     return str;
 }
-
 
 InputMode KeyFilteringInputHandler::getNextMode() {
     return InputMode::SELECTION;
@@ -45,7 +30,6 @@ std::function<bool(Hotkey *)> KeyFilteringInputHandler::getFilter() {
 
                     keyStr = linux_rawname_to_yaml_name(keyStr);
 
-                    // TODO: we need a translator from key name(from config file) to linux key name
                     if (hotkey->getKeyCodes()->find(keyStr) == hotkey->getKeyCodes()->end()) {
                         return false;
                     }

--- a/src/input/handler/instruction/MoveInstruction.h
+++ b/src/input/handler/instruction/MoveInstruction.h
@@ -5,11 +5,16 @@
 class MoveInstruction : public Instruction {
 private:
     HotkeyPickerMove moveDirection;
+    unsigned int moveSteps = 1;
 public:
     HotkeyPickerMove getMoveDirection() {
         return this->moveDirection;
     }
 
-    explicit MoveInstruction(HotkeyPickerMove moveDirection) : Instruction(InstructionType::MOVE),
-                                                                    moveDirection(moveDirection) {}
+    explicit MoveInstruction(HotkeyPickerMove moveDirection, unsigned int moveSteps) : Instruction(InstructionType::MOVE),
+                                                                    moveDirection(moveDirection), moveSteps(moveSteps) {}
+
+    unsigned int getMoveSteps() const {
+        return moveSteps;
+    }
 };

--- a/src/lib/keycode/CMakeLists.txt
+++ b/src/lib/keycode/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(keycode SHARED
         depp-keycode/src/linux_name.c
         depp-keycode/src/linux_rawname.c
         depp-keycode/src/linux_tohid.c
-        )
+        keycode.cpp)
 
 install(TARGETS keycode
         EXPORT keycode-targets
@@ -22,4 +22,4 @@ install(TARGETS keycode
 install(EXPORT keycode-targets
         DESTINATION lib/keycode)
 
-set_target_properties(keycode PROPERTIES PUBLIC_HEADER depp-keycode/src/keycode.h)
+set_target_properties(keycode PROPERTIES PUBLIC_HEADER keycode.h)

--- a/src/lib/keycode/keycode.cpp
+++ b/src/lib/keycode/keycode.cpp
@@ -1,0 +1,20 @@
+#include <string>
+#include "depp-keycode/src/keytable.h"
+
+std::string linux_rawname_to_yaml_name(std::string linux_rawname) {
+    if (linux_rawname.rfind("LEFT", 0) == 0) {
+        linux_rawname = linux_rawname.substr(4, std::string::npos);
+    } else if (linux_rawname.rfind("RIGHT", 0) == 0) {
+        linux_rawname = linux_rawname.substr(5, std::string::npos);
+    }
+
+    if (linux_rawname == "CTRL") {
+        linux_rawname = "CONTROL";
+    }
+
+    return linux_rawname;
+}
+
+std::string linux_keycode_to_yaml_name(unsigned linux_keycode) {
+    return linux_rawname_to_yaml_name(keycode_linux_rawname(linux_keycode));
+}

--- a/src/lib/keycode/keycode.h
+++ b/src/lib/keycode/keycode.h
@@ -1,7 +1,5 @@
-#ifndef DEPP_KEYCODE_LIB
-
 #include "depp-keycode/src/keytable.h"
 
-#define DEPP_KEYCODE_LIB true
+std::string linux_rawname_to_yaml_name(std::string linux_rawname);
 
-#endif
+std::string linux_keycode_to_yaml_name(unsigned linux_keycode);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -143,14 +143,15 @@ int main(int argc, char *argv[]) {
         }
 
         if (dynamic_cast<MoveInstruction *>(instruction.get())) {
-            auto move = ((MoveInstruction *) (instruction.get()))->getMoveDirection();
+            auto moveInstruction = ((MoveInstruction *) instruction.get());
+            auto move = moveInstruction->getMoveDirection();
 
             bool moved = false;
 
             XClearWindow(windowManager->getDisplay(), windowManager->getWindow());
 
             if (move != HotkeyPickerMove::NONE) {
-                moved = hotkeyPickerDrawer->move(move);
+                moved = hotkeyPickerDrawer->move(moveInstruction->getMoveDirection(), moveInstruction->getMoveSteps());
             }
 
             if (move == HotkeyPickerMove::NONE || !moved) {


### PR DESCRIPTION
Support for modifiers - we now handle `KeyRelease` events, toggle active modifiers in a set.
Repeat actions by inputting an integer before a move hotkey;
Go to end by pressing `SHIFT + G`
Go to start by pressing `g`
Go to line x by inputting the number x and then `SHIFT + G`